### PR TITLE
fix : ExceptionAdvice에서 Exception 로그 레벨 변경

### DIFF
--- a/src/main/java/com/depromeet/breadmapbackend/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/depromeet/breadmapbackend/global/exception/ExceptionAdvice.java
@@ -37,7 +37,7 @@ public class ExceptionAdvice {
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected ErrorResponse defaultException(HttpServletRequest request, Exception e) {
-        log.info(String.valueOf(e));
+        log.error(String.valueOf(e));
         e.printStackTrace();
         return new ErrorResponse(500, "unknown error");
     }


### PR DESCRIPTION
# fix : ExceptionAdvice에서 Exception 로그 레벨 변경

### 변경 사항

- ExceptionAdvice에서 Exception 로그 레벨이 info로 되어있어서 error로 변경
