### PR TITLE
refactor: profile마다 log pattern 변경

### DIFF
--- a/src/main/java/com/depromeet/breadmapbackend/global/infra/filter/LoggingFilter.java
+++ b/src/main/java/com/depromeet/breadmapbackend/global/infra/filter/LoggingFilter.java
@@ -40,11 +40,11 @@ public class LoggingFilter extends OncePerRequestFilter {
 		}
 		filterChain.doFilter(request, response);
 
-		log.info("Request Ended ==>  [REQUEST_TIME] : {} ms",
-			MDC.get(TRX_TIME.name()) != null ?
-				(System.currentTimeMillis() - Long.parseLong(MDC.get(TRX_TIME.name()))) :
-				0
-		);
+		if (!request.getRequestURI().equals("/v1/actuator/health")) {
+			log.info("Request Ended ==>  [REQUEST_TIME] : {} ms",
+				MDC.get(TRX_TIME.name()) != null ?
+					(System.currentTimeMillis() - Long.parseLong(MDC.get(TRX_TIME.name()))) : 0);
+		}
 
 		MDC.clear();
 	}

--- a/src/main/resources/logback-spring-local.xml
+++ b/src/main/resources/logback-spring-local.xml
@@ -4,7 +4,7 @@
 
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>
-                [REQUEST %X{TRX_ID}] ${LOG_PATTERN}
+                [REQUEST %X{TRX_ID}] ${LOG_PATTERN_LOCAL}
             </pattern>
             <outputPatternAsHeader>true</outputPatternAsHeader>
         </encoder>

--- a/src/main/resources/logback-spring-stage.xml
+++ b/src/main/resources/logback-spring-stage.xml
@@ -1,0 +1,16 @@
+<included>
+    <property resource="logback-variables.properties"/>
+    <appender name="MDC_REQUEST" class="ch.qos.logback.core.ConsoleAppender">
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>
+                [REQUEST %X{TRX_ID}] ${LOG_PATTERN_LOCAL}
+            </pattern>
+            <outputPatternAsHeader>true</outputPatternAsHeader>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="MDC_REQUEST"/>
+    </root>
+</included>

--- a/src/main/resources/logback-spring-stage.xml
+++ b/src/main/resources/logback-spring-stage.xml
@@ -4,7 +4,7 @@
 
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>
-                [REQUEST %X{TRX_ID}] ${LOG_PATTERN_LOCAL}
+                [REQUEST %X{TRX_ID}] ${LOG_PATTERN}
             </pattern>
             <outputPatternAsHeader>true</outputPatternAsHeader>
         </encoder>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-    <include resource="logback-spring-mdc.xml"/>
+    <springProfile name="default, local, test">
+        <include resource="logback-spring-local.xml"/>
+    </springProfile>
+    <springProfile name="stage, prod">
+        <include resource="logback-spring-stage.xml"/>
+    </springProfile>
 </configuration>

--- a/src/main/resources/logback-variables.properties
+++ b/src/main/resources/logback-variables.properties
@@ -1,1 +1,2 @@
-LOG_PATTERN=%d{yyyy-MM-dd HH:mm:ss} %clr([%-5level]) [%thread] %cyan([%logger{40}:%line]) - %msg%n
+LOG_PATTERN_LOCAL=%d{yyyy-MM-dd HH:mm:ss, ${logback.timezone:-Asia/Seoul}} %clr([%-5level]) [%thread] %cyan([%logger{40}:%line]) - %msg%n
+LOG_PATTERN=%d{yyyy-MM-dd HH:mm:ss, ${logback.timezone:-Asia/Seoul}} [%-5level] [%thread] [%logger{40}:%line] - %msg%n


### PR DESCRIPTION
# refactor: profile마다 log pattern 변경 -#266

### 변경 사항

- default/local/test에서는 색깔을 나타내는 ANSI escape 코드(%clr, %cyan) 패턴 사용, stage/prod에서는 제거한 패턴 사용
- 시간 한국 시간으로 수정 
- 헬스 체크 API (/v1/actuator/health)일 땐 Request Ended 로그 생성하지 않게 수정

<br/>

closed #266
