### PR TITLE
fix : FlagRepository의 countFlagNum 메서드 에러 수정

### DIFF
--- a/src/main/java/com/depromeet/breadmapbackend/domain/bakery/Bakery.java
+++ b/src/main/java/com/depromeet/breadmapbackend/domain/bakery/Bakery.java
@@ -4,7 +4,6 @@ import static java.lang.Math.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -144,7 +143,7 @@ public class Bakery extends BaseEntity {
 	}
 
 	public Double bakeryRating(List<Review> reviewList) {
-		return Math.floor(reviewList.stream().map(Review::getAverageRating).collect(Collectors.toList())
+		return Math.floor(reviewList.stream().map(Review::getAverageRating).toList()
 			.stream().mapToDouble(Double::doubleValue).average().orElse(0) * 10) / 10.0;
 	}
 

--- a/src/main/java/com/depromeet/breadmapbackend/domain/bakery/BakeryServiceImpl.java
+++ b/src/main/java/com/depromeet/breadmapbackend/domain/bakery/BakeryServiceImpl.java
@@ -57,7 +57,7 @@ public class BakeryServiceImpl implements BakeryService {
 			bakeryQueryRepository.findTop20BakeriesByCoordinateRange(
 				CoordinateRange.of(latitude, latitudeDelta, longitude, longitudeDelta)
 			);
-		return bakeries.size() == 0 ?
+		return bakeries.isEmpty() ?
 			List.of(new BakeryCardDto()) :
 			getBakeryCardDtos(userId, sortBy, filterBy, latitude, longitude, bakeries);
 	}
@@ -106,8 +106,7 @@ public class BakeryServiceImpl implements BakeryService {
 		final Double longitude,
 		final List<Bakery> bakeries
 	) {
-		final Map<Long, List<Review>> reviewListForAllBakeries = reviewService.getReviewListInBakeries(userId,
-			bakeries);
+		final Map<Long, List<Review>> reviewListForAllBakeries = reviewService.getReviewListInBakeries(userId, bakeries);
 		final List<BakeryCountInFlag> bakeryCountInFlags = flagRepository.countFlagNum(bakeries);
 
 		return bakeries
@@ -115,7 +114,7 @@ public class BakeryServiceImpl implements BakeryService {
 			.map(bakery -> BakeryCardDto.builder()
 				.bakery(bakery)
 				.flagNum(getFlagNum(bakeryCountInFlags, bakery))
-				.reviewList(reviewListForAllBakeries.getOrDefault(bakery.getId(), null))
+				.reviewList(reviewListForAllBakeries.getOrDefault(bakery.getId(), List.of()))
 				.distance(bakery.getDistanceFromUser(latitude, longitude))
 				.color(getFlagColor(filterBy, userId, bakery))
 				.build())
@@ -142,7 +141,7 @@ public class BakeryServiceImpl implements BakeryService {
 	private int getFlagNum(final List<BakeryCountInFlag> bakeryCountInFlags, final Bakery bakery) {
 		return bakeryCountInFlags.stream()
 			.filter(bakeryCountInFlag -> bakeryCountInFlag.getBakeryId().equals(bakery.getId()))
-			.map(BakeryCountInFlag::getCount)
+			.map(bakeryCountInFlag -> bakeryCountInFlag.getCount() == null ? 0L : bakeryCountInFlag.getCount())
 			.findFirst()
 			.orElse(0L).intValue();
 	}

--- a/src/main/java/com/depromeet/breadmapbackend/domain/flag/FlagRepository.java
+++ b/src/main/java/com/depromeet/breadmapbackend/domain/flag/FlagRepository.java
@@ -21,8 +21,7 @@ public interface FlagRepository extends JpaRepository<Flag, Long> {
 
 	Optional<Flag> findByIdAndUserId(Long flagId, Long userId);
 
-	@Query("SELECT fb.bakery.id as bakeryId, "
-		+ " count(fb.bakery) "
+	@Query("SELECT fb.bakery.id as bakeryId, count(fb.bakery) as count "
 		+ "FROM Flag f "
 		+ "INNER JOIN FlagBakery fb ON f = fb.flag "
 		+ "WHERE fb.bakery in (:bakeryList)  "


### PR DESCRIPTION
# fix : FlagRepository의 countFlagNum 메서드 에러 수정 -#281

### 변경 사항

- 2023-07-13 20:45:01 발생 오류
- getBakeryList의 getFlagNum 메서드에서 NPE 발생
- 디버깅해보니 FlagRepository의 countFlagNum 메서드로 가져오는 List<BakeryCountInFlag>에서 getCount가 null로 나옴
- 쿼리에서 count(fb.bakery)라고 되어 있고 따로 이름을 지정하지 않아서 BakeryCountInFlag Dto의 getCount()에 mapping되지 않아 발생한 문제로 파악
