### PR TITLE
fix. flyway 테이블 이름 지정

### DIFF
--- a/src/main/java/com/depromeet/breadmapbackend/domain/bakery/Bakery.java
+++ b/src/main/java/com/depromeet/breadmapbackend/domain/bakery/Bakery.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.persistence.CascadeType;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
@@ -73,6 +74,10 @@ public class Bakery extends BaseEntity {
 
 	@BatchSize(size = 2)
 	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(
+		name = "bakery_images",
+		joinColumns = @JoinColumn(name = "bakery_id")
+	)
 	private List<String> images = new ArrayList<>();
 
 	@Column(nullable = false)

--- a/src/main/resources/application-stage.yml
+++ b/src/main/resources/application-stage.yml
@@ -34,6 +34,7 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
+    baseline-version: 1
 
 oauth:
   google: ${GOOGLE_ID}


### PR DESCRIPTION
새로 만들어지는 테이블 이름 명시

Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: Invocation of init method failed; nested exception is javax.persistence.PersistenceException: [PersistenceUnit: default] Unable to build Hibernate SessionFactory; nested exception is org.hibernate.tool.schema.spi.SchemaManagementException: Schema-validation: missing table [bakery_images]